### PR TITLE
improve dishwashing a bit so that animation isn't so laggy when washing

### DIFF
--- a/dishwashing/index.js
+++ b/dishwashing/index.js
@@ -221,7 +221,10 @@ function detectSpongeToPlateContact(mouse){
     // so e.g. one sponge stroke over 1 sec can lower the plate's
     // "dirtiness" rating
     if(plateAttached && dirtiness > 0){
+        // https://stackoverflow.com/questions/47799977/three-js-raycasting-performance
+        //console.time('raycast: ');
         const gotPlate = raycaster.intersectObject(plate);
+        //console.timeEnd('raycast: ');
         
         if(gotPlate.length > 0){
             // we'll 2 results (that are the same) because a plate has 2 sides, and both
@@ -301,8 +304,16 @@ renderer.domElement.addEventListener('mousedown', (evt) => {
     }
 });
 
+let lastMove = Date.now();
 renderer.domElement.addEventListener('mousemove', (evt) => {
     if(spongeAttached){
+        // https://stackoverflow.com/questions/42232001/three-js-performance-very-slow-using-onmousemove-with-raycaster
+        if(Date.now() - lastMove < 21){
+            return;
+        }
+
+        lastMove = Date.now();
+        
         mouse.x = (evt.offsetX / evt.target.width) * 2 - 1;
         mouse.y = -(evt.offsetY / evt.target.height) * 2 + 1;
         raycaster.setFromCamera(mouse, camera);
@@ -313,7 +324,7 @@ renderer.domElement.addEventListener('mousemove', (evt) => {
         const dist = rightHand.position.distanceTo(camera.position);
         raycaster.ray.at(dist, rightHand.position);
         
-        rightHand.position.z = zPos; // lock the z-axis by reusing the same x pos
+        rightHand.position.z = zPos; // lock the z-axis by reusing the same z pos
         //console.log(rightHand.position);
         
         detectSpongeToPlateContact(mouse);

--- a/dishwashing/notes.txt
+++ b/dishwashing/notes.txt
@@ -1,10 +1,11 @@
 https://stackoverflow.com/questions/28630097/flip-mirror-any-object-with-three-js
 https://discourse.threejs.org/t/cloning-a-skinned-mesh/4775/18
 https://stackoverflow.com/questions/57381278/threejs-2d-pixels-to-3d-coordinates-conversion
+https://stackoverflow.com/questions/47799977/three-js-raycasting-performance
+https://stackoverflow.com/questions/42232001/three-js-performance-very-slow-using-onmousemove-with-raycaster
 
 TODO:
 - more plates/kitchenware
 - take into account sponge distance/movement
-- performance issues with raycasting? would web workers help?
 
 https://r105.threejsfundamentals.org/threejs/lessons/threejs-offscreencanvas.html


### PR DESCRIPTION
made a small adjustment to reduce the number of mouse move events processed thanks to Brandon Blanchard's suggestion here: https://stackoverflow.com/questions/42232001/three-js-performance-very-slow-using-onmousemove-with-raycaster (also thanks to the user who posted the question). doing this helps prevent animation from basically stopping while raycasting. :D

before (notice how the left hand just stops moving):
![25-07-2023_193641](https://github.com/syncopika/threejs-projects/assets/8601582/1a63921e-5168-4cbd-a871-d558dcb7921b)

after (no hand stopping!):
![25-07-2023_193718](https://github.com/syncopika/threejs-projects/assets/8601582/93324490-08af-4388-908a-d56d3698e365)
